### PR TITLE
Clarify plugin usage in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -48,6 +48,31 @@ module.exports = {
 Any pattern supported by [`fast-glob`](https://github.com/mrmlnc/fast-glob) is allowed here
 (including negations).
 
+`src` paths are relative to the location of your `docusaurus.config.js`. For example, if you
+had a directory structure like:
+
+```
+.
+├── LICENSE
+├── README.md
+├── package.json
+├── src
+...
+├── website
+│   ├── README.md
+│   ├── babel.config.js
+│   ├── blog
+│   ├── docs
+│   ├── docusaurus.config.js
+|   ...
+│   ├── src
+│   └── yarn.lock
+└── yarn.lock
+```
+
+Then to document all of your JSX components in your `src/` directory, you would use this path:
+`../src/**/*.jsx`.
+
 ## Reading Annotations
 
 Using the default settings, annotations are stored inside of the `.docusaurus` directory. The
@@ -100,6 +125,9 @@ export const PropTable = ({ name }) => {
   );
 };
 ```
+
+**N.b.** If you use `global: true`, then you must use the [`useGlobalData` hook](https://docusaurus.io/docs/docusaurus-core#useGlobalData)
+to access the docgen data. You cannot use `useDynamicImport`.
 
 ## Options
 


### PR DESCRIPTION
I had some trouble getting started with this plugin, probably my fault because I'm not very familiar with Docusuarus.

The example config in the README shows setting `global: true`. Later, the README also shows an example of using `useDynamicImport` to create a `PropTable` component.

I copied both examples from the README and was very confused when the `PropTable` component did not appear to work. I was also confused as the README said that the docgen data would be stored in the `.docusaurus` directory, but I could not find any obvious trace of it.

It was only after reading the code that I figured out that the `global: true` flag from the example meant that I had to use `useGlobalData` in `PropTable`, and that that was what "global data" meant.

I was also confused as to how to form the `src` paths. The README only shows paths relative to the current directory, but I didn't know _what_ the current directory would be. Admittedly, this was more confusing for me because of the issue I had above with the global data. But I think it also would have been useful to know that the `src` paths are relative to the `docusuarus.config.js`.

I think adding some clarification to the README would help people like me who might not be familiar with all of Docusaurus' concepts.