### PR TITLE
fix: convert JS Array to multiple Glob matching pattern

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -60,7 +60,7 @@ export default function plugin(
         tsConfig,
         compilerOptions,
         parserOptions
-      )(await glob(Array.isArray(src) ? src.join(',') : src));
+      )(await glob(Array.isArray(src) ? `{${src.join(',')}}` : src));
     },
     configureWebpack(config) {
       return {


### PR DESCRIPTION
`glob` has differnet matching patterns than `globby`.

https://github.com/isaacs/node-glob/issues/217